### PR TITLE
Fix path for OPA request

### DIFF
--- a/src/Auth/Keycloak/KeycloakRoleClaimTransformation.cs
+++ b/src/Auth/Keycloak/KeycloakRoleClaimTransformation.cs
@@ -20,7 +20,8 @@ namespace Tlabs.Server.Auth.Keycloak {
         var roles = seri.LoadObj(realmAccessClaim.Value) ?? new();
         if (roles.TryGetValue("roles", out var rolesElement)) {
           foreach (var role in rolesElement) {
-            identity.AddClaim(new Claim(identity.RoleClaimType, role));
+            if(!identity.HasClaim(identity.RoleClaimType, role))
+              identity.AddClaim(new Claim(identity.RoleClaimType, role));
           }
         }
       }

--- a/src/Auth/Opa/OpaAuthorizationFilter.cs
+++ b/src/Auth/Opa/OpaAuthorizationFilter.cs
@@ -35,7 +35,7 @@ namespace Tlabs.Server.Auth.Opa {
       var request = ctx.HttpContext.Request;
 
       var actionName = ctx.ActionDescriptor.DisplayName;
-      var path = request.Path.ToString()[1..].ToLowerInvariant();
+      var path = request.Path.ToString().ToLowerInvariant().Trim('/');
       var input = new OpaInput {
         Resource = actionName,
         Path = path.Split("/"),

--- a/src/Auth/Opa/OpaAuthorizationFilter.cs
+++ b/src/Auth/Opa/OpaAuthorizationFilter.cs
@@ -41,7 +41,7 @@ namespace Tlabs.Server.Auth.Opa {
       var request = ctx.HttpContext.Request;
 
       var actionName = ctx.ActionDescriptor.DisplayName;
-      var path = (ctx.ActionDescriptor.AttributeRouteInfo?.Template ?? request.Path).ToLowerInvariant();
+      var path = request.Path.ToString().ToLowerInvariant();
 
       var input = new OpaInput {
         Resource = actionName,

--- a/src/Auth/Opa/OpaAuthorizationFilter.cs
+++ b/src/Auth/Opa/OpaAuthorizationFilter.cs
@@ -1,23 +1,17 @@
 ﻿using System;
 using System.Linq;
-using System.Net.Http;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.AspNetCore.Mvc.Authorization;
 
 using Tlabs.Config;
-using Microsoft.AspNetCore.Server.HttpSys;
 using System.Security.Claims;
-using Tlabs.Server.Model;
 
 namespace Tlabs.Server.Auth.Opa {
   ///<summary>Authorization filter for Open Policy Agent.</summary>
@@ -41,8 +35,7 @@ namespace Tlabs.Server.Auth.Opa {
       var request = ctx.HttpContext.Request;
 
       var actionName = ctx.ActionDescriptor.DisplayName;
-      var path = request.Path.ToString().ToLowerInvariant();
-
+      var path = request.Path.ToString()[1..].ToLowerInvariant();
       var input = new OpaInput {
         Resource = actionName,
         Path = path.Split("/"),

--- a/src/Auth/Opa/OpaClient.cs
+++ b/src/Auth/Opa/OpaClient.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Reflection.Emit;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,7 +11,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 using Tlabs.Config;
-using Tlabs.Data.Serialize;
 using Tlabs.Data.Serialize.Json;
 using Tlabs.Server.Auth.Keycloak;
 

--- a/src/Config/BffIdentityConfigurator.cs
+++ b/src/Config/BffIdentityConfigurator.cs
@@ -101,6 +101,7 @@ namespace Tlabs.Server.Config {
 
       services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>(); //typically AddIdentity() already registers the accessor
       services.AddSingleton<IIdentityAccessor, HttpContextIdentityAccessor>();
+      services.AddScoped<IClaimsTransformation, KeycloakRolesClaimsTransformation>();
     }
   }
 }

--- a/src/Config/KeycloakIdentityConfigurator.cs
+++ b/src/Config/KeycloakIdentityConfigurator.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Authentication;
 using Tlabs.Server.Auth.Keycloak;
+using Tlabs.Identity;
 
 namespace Tlabs.Config {
   ///<summary>Configures Identity Framework.</summary>
@@ -53,6 +54,7 @@ namespace Tlabs.Config {
       services.AddHttpClient();
 
       services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>(); //typically AddIdentity() already registers the accessor
+      services.AddSingleton<IIdentityAccessor, HttpContextIdentityAccessor>();
       services.AddScoped<IClaimsTransformation, KeycloakRolesClaimsTransformation>();
       log.LogInformation("AspNetCore.Identity services added");
     }

--- a/src/Tlabs.SrvBase.csproj
+++ b/src/Tlabs.SrvBase.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.3.2</VersionPrefix>
-    <VersionSuffix>beta4</VersionSuffix>
+    <VersionSuffix>beta5</VersionSuffix>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
The `ctx.ActionDescriptor.AttributeRouteInfo?.Template` actually returns the template of the API, not an actual path, so if wildcard is in the template or more complex cases like `{**rest}` are used, the path will be assigned as `{**rest}`